### PR TITLE
header issue #6

### DIFF
--- a/library/src/main/java/com/kiguruming/recyclerview/itemdecoration/PinnedHeaderItemDecoration.java
+++ b/library/src/main/java/com/kiguruming/recyclerview/itemdecoration/PinnedHeaderItemDecoration.java
@@ -116,7 +116,7 @@ public class PinnedHeaderItemDecoration extends RecyclerView.ItemDecoration {
 
             // measure & layout
             final int ws = View.MeasureSpec.makeMeasureSpec(parent.getWidth() - parent.getPaddingLeft() - parent.getPaddingRight(), View.MeasureSpec.EXACTLY);
-            final int hs = View.MeasureSpec.makeMeasureSpec(heightSize, heightMode);
+            final int hs = View.MeasureSpec.makeMeasureSpec(heightSize - 1, heightMode);
             mPinnedHeaderView.measure(ws, hs);
             mPinnedHeaderView.layout(0, 0, mPinnedHeaderView.getMeasuredWidth(), mPinnedHeaderView.getMeasuredHeight());
         }


### PR DESCRIPTION
PinnedHeaderIconDecorator gets the wrong viewHolder.itemView, when the recycler view is scrolled very slow

After the PinnedHeaderIconDecorator is already rendering a new header, there is a certain amout of height, where the old header will get assigned to the mPinnedHeaderView. 

I guess this is an workaround only, but it does not add too much boiler-plate code.